### PR TITLE
crash during audit processing.

### DIFF
--- a/src/peersafe/app/table/impl/TableDumpItem.cpp
+++ b/src/peersafe/app/table/impl/TableDumpItem.cpp
@@ -371,7 +371,7 @@ void TableDumpItem::SetStopInfo(FILE *fileTarget, std::string sMsg)
     sWrite += sPos;
 
     fwrite(sWrite.c_str(), 1, sWrite.size(), fp);
-    fclose(fp);
+    if(fileTarget == NULL)       fclose(fp);
 }
 
 void TableDumpItem::SetErroeInfo2FileEnd(FILE *fileTarget)


### PR DESCRIPTION
reason: close two times when the audit task ends.
resolve: check the file handle whether is new openned before close it .
affect: dump and audit task . stop when catching the latest ledger.