### PR TITLE
The progress about syncing table will not go ahead BC we get the wrong Tx.

### DIFF
--- a/src/peersafe/app/tx/impl/SqlStatement.cpp
+++ b/src/peersafe/app/tx/impl/SqlStatement.cpp
@@ -150,11 +150,17 @@ namespace ripple {
 
 		auto const & sTxTables = tx.getFieldArray(sfTables);
 		Blob vTxTableName = sTxTables[0].getFieldVL(sfTableName);
+        uint160 uTxDBName = sTxTables[0].getFieldH160(sfNameInDB);
 
 		STArray const & aTableEntries(sleTable->getFieldArray(sfTableEntries));
-		STEntry *pEntry = getTableEntry(aTableEntries, vTxTableName);
+		STEntry *pEntry = getTableEntry(aTableEntries, vTxTableName);        
 		if (pEntry)
 		{
+            //checkDBName
+            if (uTxDBName != pEntry->getFieldH160(sfNameInDB))
+            {
+                return terBAD_DBNAME;
+            }
 			// strict mode
 			if (tx.isFieldPresent(sfTxCheckHash))
 			{
@@ -207,8 +213,7 @@ namespace ripple {
 		auto &aTableEntries = pTableSle->peekFieldArray(sfTableEntries);
 
 		auto const & sTxTables = tx.getFieldArray(sfTables);
-		Blob vTxTableName = sTxTables[0].getFieldVL(sfTableName);
-		uint160 uTxDBName = sTxTables[0].getFieldH160(sfNameInDB);
+		Blob vTxTableName = sTxTables[0].getFieldVL(sfTableName);		
 
 		STEntry *pEntry = getTableEntry(aTableEntries, vTxTableName);
 		if (pEntry)

--- a/src/ripple/protocol/TER.h
+++ b/src/ripple/protocol/TER.h
@@ -187,6 +187,7 @@ enum TER
     terNO_ACCOUNT,       // Can't pay fee, therefore don't burden network.
     terNO_AUTH,          // Not authorized to hold IOUs.
     terNO_LINE,          // Internal flag.
+    terBAD_DBNAME,       // NameInDB does not match tableName.
     terOWNERS,           // Can't succeed with non-zero owner count.
     terPRE_SEQ,          // Can't pay fee, no point in forwarding, so don't
                          // burden network.

--- a/src/ripple/protocol/impl/TER.cpp
+++ b/src/ripple/protocol/impl/TER.cpp
@@ -168,6 +168,7 @@ transResults()
 		{ terNO_RIPPLE,              { "terNO_RIPPLE",             "Path does not permit rippling."                                                } },
 		{ terNO_ACCOUNT,             { "terNO_ACCOUNT",            "The source account does not exist."                                            } },
 		{ terNO_AUTH,                { "terNO_AUTH",               "Not authorized to hold IOUs."                                                  } },
+        { terBAD_DBNAME,             { "terBAD_DBNAME",            "NameInDB does not match tableName." } },
 		{ terNO_LINE,                { "terNO_LINE",               "No such line."                                                                 } },
 		{ terPRE_SEQ,                { "terPRE_SEQ",               "Missing/inapplicable prior transaction."                                       } },
 		{ terOWNERS,                 { "terOWNERS",                "Non-zero owner count."                                                         } },


### PR DESCRIPTION
reason:   the tx which has wrong dbname.can accepted by the consensus workflow, so we get the wrong db info
modify:   check the tx before consensus workflow accepted it  to make sure the tablename can match the dbname.
affect:   just sqlstatement operation.