### PR TITLE
jira--RR419

### DIFF
--- a/src/peersafe/app/table/impl/TableDumpItem.cpp
+++ b/src/peersafe/app/table/impl/TableDumpItem.cpp
@@ -41,6 +41,10 @@ TableDumpItem::TableDumpItem(Application& app, beast::Journal journal, Config& c
 {       
 	sDumpPath_            = "";
 	funDumpCB_            = NULL;
+    uTxSeqRecord_         = 0;
+    sTxHashRecord_        = "";
+    uLedgerSeqRecord_     = 0;
+    sLedgerHashRecord_    = "";
 }
 
 std::pair<int,int> TableDumpItem::GetRightTxEndPos(FILE * fp, bool &bEmptyTx)


### PR DESCRIPTION
reason: forget to initialize the dump paras for the table.
modify: initialize paras for the dumping talbe.
affect :  dump and audit , like this case.