### PR TITLE
RR380_fail to redump file when set the incorrect target file at the first time.

### DIFF
--- a/src/peersafe/app/table/impl/TableDumpItem.cpp
+++ b/src/peersafe/app/table/impl/TableDumpItem.cpp
@@ -129,14 +129,17 @@ std::pair<bool, std::string> TableDumpItem::SetDumpPara(std::string sPath, funDu
             //check first
             if (to_string(accountID_) != pos["Account"].asString())
             {
+                fclose(fDump);
                 return std::make_pair(false, "account in parameter list is different form in target file, please set a new target file.");
             }
             if (sTableName_ != pos["TableName"].asString())
             {
+                fclose(fDump);
                 return std::make_pair(false, "tablename in parameter list is different form in target file, please set a new target file.");
             }
             if (uCreateLedgerSequence_ != pos["TxnCreateSeq"].asUInt())
             {
+                fclose(fDump);
                 return std::make_pair(false, sTableName_ + " is a new created file," + sTableName_ + " in target file may have been deleted , please set a new target file.");
             }
 


### PR DESCRIPTION
reason: forget to close file when get the error target.
modify: close file in chainsql.
affect: dump function,just this case