### PR TITLE
Bugfig/node crash bc transaction

### DIFF
--- a/src/peersafe/app/sql/TxStore.cpp
+++ b/src/peersafe/app/sql/TxStore.cpp
@@ -175,8 +175,8 @@ std::pair<bool, std::string> TxStore::DropTable(const std::string& tablename) {
     if (bExist)
     {
         std::string sql_str = std::string("drop table t_") + tablename;
-        soci::session& sql = *databasecon_->checkoutDb();
-        sql << sql_str;
+        LockedSociSession sql = databasecon_->checkoutDb();
+        *sql << sql_str;
     }
     else
     {

--- a/src/peersafe/app/table/impl/TableSync.cpp
+++ b/src/peersafe/app/table/impl/TableSync.cpp
@@ -1159,7 +1159,8 @@ void TableSync::TableSyncThread()
 						{
 							bAutoSync = false;
 						}
-                        InsertSnycDB(stItem.sTableName, nameInDB, to_string(stItem.accountID), LedgerSeq, LedgerHash, bAutoSync, "");                        app_.getTableStatusDB().UpdateSyncDB(to_string(stItem.accountID), nameInDB, to_string(TxnLedgerHash), to_string(TxnLedgerSeq), to_string(LedgerHash), to_string(LedgerSeq), "", "", "");
+                        InsertSnycDB(stItem.sTableName, nameInDB, to_string(stItem.accountID), LedgerSeq, LedgerHash, bAutoSync, "");         
+                        app_.getTableStatusDB().UpdateSyncDB(to_string(stItem.accountID), nameInDB, to_string(TxnLedgerHash), to_string(TxnLedgerSeq), to_string(LedgerHash), to_string(LedgerSeq), "", "", "");
                     }
 					pItem->SetPara(nameInDB, LedgerSeq, LedgerHash, TxnLedgerSeq, TxnLedgerHash, TxnUpdateHash);
 

--- a/src/peersafe/app/tx/OperationRule.h
+++ b/src/peersafe/app/tx/OperationRule.h
@@ -11,14 +11,14 @@ namespace ripple {
 class OperationRule {
 public:
 	//for TableListSet
-	static TER dealWithTableListSetRule(ApplyContext& ctx);
+	static TER dealWithTableListSetRule(ApplyContext& ctx, const STTx& tx);
 	//for SqlStatement
-	static TER dealWithSqlStatementRule(ApplyContext& ctx);
+	static TER dealWithSqlStatementRule(ApplyContext& ctx, const STTx& tx);
 
 	static std::string getOperationRule(ApplyView& view, const STTx& tx);
 	static bool hasOperationRule(ApplyView& view, const STTx& tx);
 
-	static TER adjustInsertCount(ApplyContext& ctx, DatabaseCon* pConn);
+	static TER adjustInsertCount(ApplyContext& ctx, const STTx& tx, DatabaseCon* pConn);
 };
 
 } // ripple

--- a/src/peersafe/app/tx/impl/OperationRule.cpp
+++ b/src/peersafe/app/tx/impl/OperationRule.cpp
@@ -52,9 +52,8 @@ bool OperationRule::hasOperationRule(ApplyView& view, const STTx& tx)
 	return !rule.empty();
 }
 
-TER OperationRule::dealWithTableListSetRule(ApplyContext& ctx)
+TER OperationRule::dealWithTableListSetRule(ApplyContext& ctx, const STTx& tx)
 {
-	STTx const& tx = ctx.tx;
 	if (tx.getFieldU16(sfOpType) != T_CREATE)
 		return tesSUCCESS;
 	if (tx.isFieldPresent(sfOperationRule))
@@ -239,9 +238,8 @@ TER OperationRule::dealWithTableListSetRule(ApplyContext& ctx)
 	return tesSUCCESS;
 }
 
-TER OperationRule::dealWithSqlStatementRule(ApplyContext& ctx)
+TER OperationRule::dealWithSqlStatementRule(ApplyContext& ctx, const STTx& tx)
 {
-	STTx const& tx = ctx.tx;
 	STEntry* pEntry = getTableEntry(ctx.view(), tx);
 	auto optype = tx.getFieldU16(sfOpType);
 	auto sOperationRule = pEntry->getOperationRule((TableOpType)optype);
@@ -390,9 +388,8 @@ TER OperationRule::dealWithSqlStatementRule(ApplyContext& ctx)
 	return tesSUCCESS;
 }
 
-TER OperationRule::adjustInsertCount(ApplyContext& ctx, DatabaseCon* pConn)
-{
-	STTx const& tx = ctx.tx;
+TER OperationRule::adjustInsertCount(ApplyContext& ctx, const STTx& tx, DatabaseCon* pConn)
+{	
 	if (tx.getFieldU16(sfOpType) != R_DELETE)
 		return tesSUCCESS;
 

--- a/src/peersafe/app/tx/impl/SqlStatement.cpp
+++ b/src/peersafe/app/tx/impl/SqlStatement.cpp
@@ -300,7 +300,7 @@ namespace ripple {
 		std::string sOperationRule = OperationRule::getOperationRule(ctx_.view(), tx);
 		if (!sOperationRule.empty()) {
 			//deal with operation-rule
-			auto tmpret = OperationRule::dealWithSqlStatementRule(ctx_);
+			auto tmpret = OperationRule::dealWithSqlStatementRule(ctx_, tx);
 			if (!isTesSuccess(tmpret))
 				return std::make_pair(tmpret, "deal with operation-rule error");
 		}
@@ -314,7 +314,7 @@ namespace ripple {
 		if (ret.first)
 		{
 			//update insert sle if delete
-			TER ret2 = OperationRule::adjustInsertCount(ctx_, txStore.getDatabaseCon());
+			TER ret2 = OperationRule::adjustInsertCount(ctx_, tx,txStore.getDatabaseCon());
 			if (!isTesSuccess(ret2))
 				return std::make_pair(ret2, "Deal with delete rule error");;
 

--- a/src/peersafe/app/tx/impl/SqlTransaction.cpp
+++ b/src/peersafe/app/tx/impl/SqlTransaction.cpp
@@ -85,7 +85,7 @@ namespace ripple {
             auto &tables = txTmp.getFieldArray(sfTables);
             uint160 nameInDB = tables[0].getFieldH160(sfNameInDB);
 			if((TableOpType)obj["OpType"].asInt() == T_CREATE)
-				ctx_.app.getTxStore().DropTable(to_string(nameInDB));
+                txStore.DropTable(to_string(nameInDB));
         }
 
         {

--- a/src/peersafe/app/tx/impl/TableListSet.cpp
+++ b/src/peersafe/app/tx/impl/TableListSet.cpp
@@ -749,7 +749,7 @@ namespace ripple {
 
 	std::pair<TER, std::string> TableListSet::dispose(TxStore& txStore, const STTx& tx)
 	{
-		TER tmpRet = OperationRule::dealWithTableListSetRule(ctx_);
+		TER tmpRet = OperationRule::dealWithTableListSetRule(ctx_, tx);
 		if (!isTesSuccess(tmpRet))
 			return std::make_pair(tmpRet, "deal with operation-rule error");
 		return ChainSqlTx::dispose(txStore, tx);
@@ -771,7 +771,7 @@ namespace ripple {
 		TER tmpRet = tesSUCCESS;
 		if (canDispose(ctx_))
 		{
-			tmpRet = OperationRule::dealWithTableListSetRule(ctx_);
+			tmpRet = OperationRule::dealWithTableListSetRule(ctx_, ctx_.tx);
 			if (!isTesSuccess(tmpRet))
 				return tmpRet;
 		}


### PR DESCRIPTION
RR-432  RR-406

reason: using the connect db incorrectly.
modify: lock the connection before use it .
affection: all create operation ,including transaction.