### PR TITLE
change the count of sync task 

### DIFF
--- a/src/ripple/core/JobTypes.h
+++ b/src/ripple/core/JobTypes.h
@@ -67,7 +67,7 @@ add(    jtTABLESTORAGE,  "tableStorage",            1,        false, 0,     0);
 add(	jtTableCheckHash, "tableCheckHash",			1,		  false, 0,		0);
 add(	jtCheckSubTx,	  "checkSubTx",				1,		  false, 0,		0);
 add(    jtTABLELOCALSYNC,"tableLocalSync",          1,        false, 0,     0);
-add(    jtOPERATESQL,    "operateSQL",              1,        false, 0,     0);
+add(    jtOPERATESQL,    "operateSQL",              10,        false, 0,     0);
 add(    jtTABLE_REQ,     "tableRequest",            2,        false, 0,     0);
 add(    jtTABLE_DATA,    "tableData",               2,        false, 0,     0);
 add(    jtSKIPNODE,      "skipnode",                2,        false, 0,     0);


### PR DESCRIPTION
change the count of sync task from 1 to 10, so we can sync tables quicker than before.