### PR TITLE
reason: using the same output fine between different processes.

### DIFF
--- a/src/peersafe/app/table/TableDumpItem.h
+++ b/src/peersafe/app/table/TableDumpItem.h
@@ -36,6 +36,7 @@ public:
 
 	std::pair<bool, std::string> SetDumpPara(std::string sPath, funDumpCB funCB);
     std::pair<bool, std::string> StopTask();
+    std::string GetOutputPath() { return sDumpPath_; }
 
 protected:
     std::string ConstructTxStr(std::vector<STTx> &vecTxs, const STTx & tx);

--- a/src/peersafe/app/table/TableSync.h
+++ b/src/peersafe/app/table/TableSync.h
@@ -70,7 +70,6 @@ public:
 	std::pair<bool, std::string> StartDumpTable(std::string sPara, std::string sPath, TableDumpItem::funDumpCB funCB);
 	std::pair<bool, std::string> StopDumpTable(AccountID accountID, std::string sTableName);
 
-    std::pair<bool, std::string> StartAuditTable(std::string sPara, std::string sPath, const std::list<int>& idArray, const std::list<std::string> & fieldArray);
     std::pair<bool, std::string> StartAuditTable(std::string sPara, std::string sSql, std::string sPath);
     std::pair<bool, std::string> StopAuditTable(std::string sNickName);
 


### PR DESCRIPTION
modifier: check if the output file has been used before using it.
affection: audit task.